### PR TITLE
Jasondcamp hide commands

### DIFF
--- a/handler/actions.go
+++ b/handler/actions.go
@@ -11,6 +11,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const TICK = "`"
+
 var (
 	actions = map[string]regexp.Regexp{
 		"hello":         *regexp.MustCompile(`hello.+`),
@@ -590,5 +592,32 @@ func (h *Handler) prune(ea *EventAction) error {
 
 	h.reply(ea, msgQueuesPruned, false)
 
+	return nil
+}
+
+func (h *Handler) help(ea *EventAction) error {
+	var helpText = "Hello! I can be used via any channel that I have been added to or via DM. Regardless of where you invoke a command, there is a single reservation system that will be shared.\n\n"
+	if h.reqEnv == true {
+		helpText += "I can handle multiple environments or namespaces. A resource is defined as " + TICK + "env|name" + TICK + ".\n\n"
+	} else {
+		helpText += "A resource is defined as " + TICK + "name" + TICK + ".\n\n"
+	}
+
+	helpText += "When invoking via DM, I will alert other users via DM when necessary. E.g. Releasing a resource will notify the next user that has it.\n\n"
+	helpText += "*Commands*\n\n"
+	helpText += "When invoking within a channel, you must @-mention me by adding " + TICK + "@reservebot" + TICK + "to the _beginning_ of your command.\n\n"
+
+	helpText += TICK + "reserve <resource>" + TICK + " This will reserve a given resource for the user. If the resource is currently reserved, the user will be placed into the queue. The resource should be an alphanumeric string with no spaces. A comma-separted list can be used to reserve multiple resources.\n\n"
+	helpText += TICK + "release <resource>" + TICK + " This will release a given resource. This command must be executed by the person who holds the resource. Upon release, the next person waiting in line will be notified that they now have the resource. The resource should be an alphanumeric string with no spaces. A comma-separted list can be used to reserve multiple resources.\n\n"
+	helpText += TICK + "status" + TICK + " This will provide a status of all active resources.\n\n"
+	helpText += TICK + "my status" + TICK + " This will provide a status of all active and queue reservations for the user.\n\n"
+	helpText += TICK + "status <resource>" + TICK + " This will provide a status of a given resource.\n\n"
+	helpText += TICK + "remove me from <resource>" + TICK + " This will remove the user from the queue for a resource.\n\n"
+	helpText += TICK + "clear <resource>" + TICK + " This will clear the queue for a given resource and release it.\n\n"
+	helpText += TICK + "prune <resource>" + TICK + " This will clear all unreserved resources from memory.\n\n"
+	helpText += TICK + "kick <@user>" + TICK + " This will kick the mentioned user from _all_ resources they are holding. As the user is kicked from each resource, the queue will be advanced to the next user waiting.\n\n"
+	helpText += TICK + "nuke" + TICK + " This will clear all reservations and all queues for all resources. This can only be done from a public channel, not a DM. There is no confirmation, so be careful.\n\n"
+
+	h.reply(ea, helpText, false)
 	return nil
 }

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -298,6 +298,7 @@ func (h *Handler) sendDM(user *models.User, msg string) error {
 	return err
 }
 
+
 const helpText = `
 Hello! I can be used via any channel that I have been added to or via DM. Regardless of where you invoke a command, there is a single reservation system that will be shared.
 

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -89,7 +89,7 @@ func (h *Handler) CallbackEvent(event slackevents.EventsAPIEvent) error {
 	case "prune", "prune_dm":
 		return h.prune(ea)
 	case "help", "help_dm":
-		return h.reply(ea, helpText, false)
+		return h.help(ea)
 	default:
 		return h.reply(ea, "I'm sorry, I don't know what to do with that request", false)
 	}
@@ -297,37 +297,3 @@ func (h *Handler) sendDM(user *models.User, msg string) error {
 	_, _, err = h.client.PostMessage(c, slack.MsgOptionText(msg, false))
 	return err
 }
-
-
-const helpText = `
-Hello! I can be used via any channel that I have been added to or via DM. Regardless of where you invoke a command, there is a single reservation system that will be shared.
-
-I can handle multiple environments or namespaces. A resource is defined as ` + "`" + `env|name` + "`" + `.
-
-When invoking via DM, I will alert other users via DM when necessary. E.g. Releasing a resource will notify the next user that has it.
-
-*Commands*
-
-When invoking within a channel, you must @-mention me by adding ` + "`@reservebot`" + ` to the _beginning_ of your command.
-
-` + "`reserve <resource>`" + ` This will reserve a given resource for the user. If the resource is currently reserved, the user will be placed into the queue. The resource should be an alphanumeric string with no spaces. A comma-separted list can be used to reserve multiple resources.
-
-` + "`release <resource>`" + ` This will release a given resource. This command must be executed by the person who holds the resource. Upon release, the next person waiting in line will be notified that they now have the resource. The resource should be an alphanumeric string with no spaces. A comma-separted list can be used to reserve multiple resources.
-
-` + "`status`" + ` This will provide a status of all active resources.
-
-` + "`my status`" + ` This will provide a status of all active and queue reservations for the user.
-
-` + "`status <resource>`" + ` This will provide a status of a given resource.
-
-` + "`remove me from <resource>`" + ` This will remove the user from the queue for a resource.
-
-` + "`clear <resource>`" + ` This will clear the queue for a given resource and release it.
-
-` + "`prune`" + ` This will clear all unreserved resources from memory.
-
-` + "`kick <@user>`" + ` This will kick the mentioned user from _all_ resources they are holding. As the user is kicked from each resource, the queue will be advanced to the next user waiting.
-
-` + "`nuke`" + ` This will clear all reservations and all queues for all resources. This can only be done from a public channel, not a DM. There is no confirmation, so be careful.
-
-`

--- a/reservebot.go
+++ b/reservebot.go
@@ -20,8 +20,6 @@ var (
 	challenge      string
         listenPort     int
 	debug          bool
-	enablePrune    bool
-	enableNuke     bool
 	reqResourceEnv bool
 )
 
@@ -30,8 +28,6 @@ func main() {
 	flag.StringVar(&challenge, "challenge", "", "Slack verification token")
 	flag.IntVar(&listenPort, "listen-port", 666, "Listen port")
 	flag.BoolVar(&debug, "debug", false, "Debug mode")
-        flag.BoolVar(&enablePrune, "enable-prune", true, "Enable prune command")
-        flag.BoolVar(&enableNuke, "enable-nuke", true, "Enable nuke command")
 	flag.BoolVar(&reqResourceEnv, "require-resource-env", true, "Require resource reservation to include environment")
 	flag.Parse()
 

--- a/reservebot.go
+++ b/reservebot.go
@@ -19,8 +19,8 @@ var (
 	token          string
 	challenge      string
 	debug          bool
-	enable_prune   bool
-	enable_nuke    bool
+	enablePrune    bool
+	enableNuke     bool
 	reqResourceEnv bool
 )
 
@@ -28,8 +28,8 @@ func main() {
 	flag.StringVar(&token, "token", "", "Slack API Token")
 	flag.StringVar(&challenge, "challenge", "", "Slack verification token")
 	flag.BoolVar(&debug, "debug", false, "Debug mode")
-        flag.BoolVar(&enable_prune, "enable-prune", true, "Enable prune command")
-        flag.BoolVar(&enable_nuke, "enable-nuke", true, "Enable nuke command")
+        flag.BoolVar(&enablePrune, "enable-prune", true, "Enable prune command")
+        flag.BoolVar(&enableNuke, "enable-nuke", true, "Enable nuke command")
 	flag.BoolVar(&reqResourceEnv, "require-resource-env", true, "Require resource reservation to include environment")
 	flag.Parse()
 

--- a/reservebot.go
+++ b/reservebot.go
@@ -19,6 +19,8 @@ var (
 	token          string
 	challenge      string
 	debug          bool
+	enable_prune   bool
+	enable_nuke    bool
 	reqResourceEnv bool
 )
 
@@ -26,6 +28,8 @@ func main() {
 	flag.StringVar(&token, "token", "", "Slack API Token")
 	flag.StringVar(&challenge, "challenge", "", "Slack verification token")
 	flag.BoolVar(&debug, "debug", false, "Debug mode")
+        flag.BoolVar(&enable_prune, "enable-prune", true, "Enable prune command")
+        flag.BoolVar(&enable_nuke, "enable-nuke", true, "Enable nuke command")
 	flag.BoolVar(&reqResourceEnv, "require-resource-env", true, "Require resource reservation to include environment")
 	flag.Parse()
 


### PR DESCRIPTION
Moved help command into a function in order to easily modify help output based on the options passed on the cmd line. For example, if `require-resource-env` is true, it will show output for `namespace|env` but if it is false, it will show output for `env`.

I plan on using this also in a future PR to limit admin commands via a flag.