### PR TITLE
Clean up help command, clean kick command, added admins flag (#20)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@
 # Dependency directories (remove the comment below to include it)
 # vendor/
 
+# swp
+*.swp
+
 # bot name
 reservebot

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY . .
 
 RUN go build -o /app
 
+
 EXPOSE 666
 
-ENTRYPOINT ["/app/reservebot", "-token", "$SLACK_TOKEN", "-challenge", "$SLACK_CHALLENGE"]
+ENTRYPOINT ["/app/reservebot"]

--- a/README.md
+++ b/README.md
@@ -29,9 +29,12 @@ $ ./reservebot -token "<YOUR_SLACK_TOKEN>" -challenge "<SLACK_VERIFICATION_TOKEN
 Then in Slack, set up "event subscriptions" for `<ngrok url from your terminal>/events`.
 
 ### Docker
+The docker run uses environment variables. The following are supported - `SLACK_TOKEN`, `SLACK_CHALLENGE`, `LISTEN_PORT`, `DEBUG`, `SLACK_ADMINS`, `REQUIRE_RESOURCE_ENV`, `PRUNE_ENABLED`, `PRUNE_INTERVAL`, `PRUNE_EXPIRE`.
+
+Run docker as follows:
 ```
 $ docker build -t reservebot .
-$ docker run [-d] -p 666:666 reservebot -token "<YOUR_SLACK_TOKEN>" -challenge "<SLACK_VERIFICATION_TOKEN>"
+$ docker run [-d] -p 666:666 reservebot -e SLACK_TOKEN=<YOUR_SLACK_TOKEN> -e SLACK_CHALLENGE=<SLACK_VERIFICATION_TOKEN>
 ```
 
 ## Setting up Slack
@@ -67,6 +70,12 @@ In Slack...
 When invoking via DM, the bot will alert other users via DM when necessary. E.g. Releasing a resource will notify the next user that has it.
 
 By default, resources must be in the format of `namespace|resource`. However, if you do not have a need to use namespaces, you can disable this at runtime using the argument `--require-resource-env=false`
+
+The default listen port is `666` but can be overridden with `--listen-port=667`
+
+`--admins=<slackuser1>,<slackuser2>` can be specified to restrict the `prune`, `nuke`, and `kick` commands to people on this list. This is to prevent anyone from accidentally running these commands.  Not specifying `--admins` allows all users to run these commands.
+
+Pruning is enabled by default, it can be disabled by setting `--prune-enabled=false`. The prune interval can be changed from the default of 1 hour by using `--prune-interval=6`. The expiration time for resources can be changed from the default of 1 week by using `--prune-expire=24`.
 
 ## Commands
 

--- a/reservebot.go
+++ b/reservebot.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ameliagapin/reservebot/data"
 	"github.com/ameliagapin/reservebot/handler"
+	"github.com/ameliagapin/reservebot/util"
 	log "github.com/sirupsen/logrus"
 	"github.com/slack-go/slack"
 	"github.com/slack-go/slack/slackevents"
@@ -18,19 +19,28 @@ import (
 var (
 	token          string
 	challenge      string
-        listenPort     int
+	listenPort     int
 	debug          bool
+	admins         string
 	reqResourceEnv bool
+	pruneEnabled   bool
+	pruneInterval  int
+	pruneExpire    int
 )
 
 func main() {
-	flag.StringVar(&token, "token", "", "Slack API Token")
-	flag.StringVar(&challenge, "challenge", "", "Slack verification token")
-	flag.IntVar(&listenPort, "listen-port", 666, "Listen port")
-	flag.BoolVar(&debug, "debug", false, "Debug mode")
-	flag.BoolVar(&reqResourceEnv, "require-resource-env", true, "Require resource reservation to include environment")
+	flag.StringVar(&token, "token", util.LookupEnvOrString("SLACK_TOKEN", ""), "Slack API Token")
+	flag.StringVar(&challenge, "challenge", util.LookupEnvOrString("SLACK_CHALLENGE", ""), "Slack verification token")
+	flag.IntVar(&listenPort, "listen-port", util.LookupEnvOrInt("LISTEN_PORT", 666), "Listen port")
+	flag.BoolVar(&debug, "debug", util.LookupEnvOrBool("DEBUG", false), "Debug mode")
+	flag.StringVar(&admins, "admins", util.LookupEnvOrString("SLACK_ADMINS", ""), "Turn on administrative commands for specific admins, comma separated list")
+	flag.BoolVar(&reqResourceEnv, "require-resource-env", util.LookupEnvOrBool("REQUIRE_RESOURCE_ENV", true), "Require resource reservation to include environment")
+	flag.BoolVar(&pruneEnabled, "prune-enabled", util.LookupEnvOrBool("PRUNE_ENABLED", true), "Enable pruning available resources automatically")
+	flag.IntVar(&pruneInterval, "prune-interval", util.LookupEnvOrInt("PRUNE_INTERVAL", 1), "Automatic pruning interval in hours")
+	flag.IntVar(&pruneExpire, "prune-expire", util.LookupEnvOrInt("PRUNE_EXPIRE", 168), "Automatic prune expiration time in hours")
 	flag.Parse()
 
+	// Make sure required vars are set
 	if token == "" {
 		log.Error("Slack token is required")
 		return
@@ -43,20 +53,27 @@ func main() {
 	api := slack.New(token, slack.OptionDebug(debug))
 
 	data := data.NewMemory()
-	// Prune inactive resources once an hour
-	go func() {
-		for {
-			time.Sleep(time.Hour)
-			err := data.PruneInactiveResources(168) // one week
-			if err != nil {
-				log.Errorf("Error pruning resources: %+v", err)
-			} else {
-				log.Infof("Pruned resources")
-			}
-		}
-	}()
 
-	handler := handler.New(api, data, reqResourceEnv)
+	if pruneEnabled {
+		// Prune inactive resources
+		log.Infof("Automatic Pruning is enabled.")
+		go func() {
+			for {
+				time.Sleep(time.Duration(pruneInterval) * time.Hour)
+				err := data.PruneInactiveResources(pruneExpire)
+				if err != nil {
+					log.Errorf("Error pruning resources: %+v", err)
+				} else {
+					log.Infof("Pruned resources")
+				}
+			}
+		}()
+
+	} else {
+		log.Infof("Automatic pruning is disabled.")
+	}
+
+	handler := handler.New(api, data, reqResourceEnv, util.ParseAdmins(admins))
 
 	http.HandleFunc("/events", func(w http.ResponseWriter, r *http.Request) {
 		buf := new(bytes.Buffer)
@@ -98,7 +115,6 @@ func main() {
 
 	log.Infof("Server listening on port %d", listenPort)
 
-	http.ListenAndServe(fmt.Sprintf(":%v", listenPort),  nil)
-
+	http.ListenAndServe(fmt.Sprintf(":%v", listenPort), nil)
 
 }

--- a/util/util.go
+++ b/util/util.go
@@ -2,7 +2,9 @@ package util
 
 import (
 	"math"
+	"os"
 	"strconv"
+	"strings"
 )
 
 func Ordinalize(num int) string {
@@ -31,3 +33,53 @@ func Ordinalize(num int) string {
 	return strconv.Itoa(num) + ordinalDictionary[positiveNum]
 
 }
+
+func LookupEnvOrString(key string, defaultVal string) string {
+	if val, ok := os.LookupEnv(key); ok {
+		return val
+	}
+	return defaultVal
+}
+
+func LookupEnvOrInt(key string, defaultVal int) int {
+	if val, ok := os.LookupEnv(key); ok {
+		v, _ := strconv.Atoi(val)
+		return v
+	}
+	return defaultVal
+}
+
+func LookupEnvOrBool(key string, defaultVal bool) bool {
+	if val, ok := os.LookupEnv(key); ok {
+		if val == "true" {
+			return true
+		} else {
+			return false
+		}
+	}
+	return defaultVal
+}
+
+func ParseAdmins(admins string) []string {
+	// Convert admins list into slice
+	var admins_ary []string
+	if len(admins) > 0 {
+		if strings.Contains(admins, ",") {
+			admins_ary = strings.Split(admins, ",")
+		} else {
+			admins_ary = append(admins_ary, admins)
+		}
+	}
+
+	return admins_ary
+}
+
+func InSlice(arr []string, str string) bool {
+	for _, a := range arr {
+		if a == str {
+			return true
+		}
+	}
+	return false
+}
+


### PR DESCRIPTION
* Added enable vars for prune and nuke

* Moved help function into handler and moved help text into function

* Fixed camelCase

* Removed enable commands I added accidentally

* Go fmt and updated the readme to reflect the listen-port option

* Added ability to specify --admins which restricts some global commands to certain slack users

* Updated readme

* Fixed env variable calls in readme and updated docker cmd

* Changed cmd back to entrypoint

* Added some regexps that catch other forms of kick, in order to provide proper error messaging. The handler processes these variations properly, they just weren't making it there because they weren't being caught

* Added support for environment variables to be set instead of command flags for docker run

* Added env var information to readme

* Removed extra char

* Cleaned up reservebot.go, moved LookupEnv funcs into utils, created parseAdmin func and moved into utils

* Added strings import to utils

* Fixed typos

* Cleaned up inslice util func, moved to util

* Added ability to disable auto pruning, our environments are static so we don't want them going away. Also added the ability to remove an individual resource so you don't hav eto prune all objects

* Changed enable-prune to prune-enabled flag, added prune-interval and prune-expire flags

* Removed swap file and added swap ignore to .gitignore

* Added helper function per @ameliagapin, added early returns for non admin status